### PR TITLE
Fix ClampedScaledMetric documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,13 @@ The instructions below guide Codex when working in this repository.
 - All Swift source files must begin with a brief file-level comment explaining the purpose of the file.
 - Public types, methods, and properties should include `///` documentation comments.
 - Use `// MARK:` to organize code into logical sections where appropriate.
+- Leave a blank line after the summary sentence in documentation comments for initializers.
+- Do not wrap system type names (e.g., CGFloat, ScaledMetric) in backticks.
+- Place `@propertyWrapper` on the same line as the type declaration and document the type.
+- Document stored properties and group them under `// MARK: - Private Properties`.
+- Surround each `// MARK:` with blank lines and use a dash separator.
+- Ensure a blank line before the closing brace of any type.
+- List computed properties before initializers.
 
 ## API Usage
 - Only use APIs available in the latest major releases of macOS, iOS, tvOS, and watchOS.

--- a/Sources/SwiftUIComponents/ClampedScaledMetric.swift
+++ b/Sources/SwiftUIComponents/ClampedScaledMetric.swift
@@ -1,0 +1,36 @@
+// Property wrapper that scales a CGFloat to a maximum value.
+
+import SwiftUI
+
+/// Scales a CGFloat to a defined maximum using ScaledMetric.
+@propertyWrapper struct ClampedScaledMetric {
+
+    // MARK: - Private Properties
+
+    /// The base value scaled according to the user's Dynamic Type setting.
+    @ScaledMetric private var metric: CGFloat
+
+    /// The upper bound for the scaled value.
+    private let maximum: CGFloat
+
+    // MARK: - Computed Properties
+
+    /// The scaled value clamped to the provided maximum.
+    var wrappedValue: CGFloat {
+        min(metric, maximum)
+    }
+
+    // MARK: - Initialization
+
+    /// Creates the wrapper with an initial value and an optional maximum.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: The base value that should be scaled.
+    ///   - maximum: The upper bound for the scaled value. If `nil`, the wrapped value is used.
+    init(wrappedValue: CGFloat, maximum: CGFloat? = nil) {
+        let resolvedMaximum = maximum ?? wrappedValue
+        self._metric = ScaledMetric(wrappedValue: wrappedValue)
+        self.maximum = resolvedMaximum
+    }
+
+}

--- a/Tests/SwiftUIComponentsTests/SwiftUIComponentsTests.swift
+++ b/Tests/SwiftUIComponentsTests/SwiftUIComponentsTests.swift
@@ -1,7 +1,26 @@
 // Tests for the SwiftUIComponents package.
 import Testing
 @testable import SwiftUIComponents
+import Foundation
 
 @Test func example() async throws {
     // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}
+
+@Test func clampedScaledMetricClamps() async throws {
+    struct Holder {
+        @ClampedScaledMetric(maximum: 20) var value: CGFloat = 25
+    }
+
+    let h = Holder()
+    #expect(h.value == 20)
+}
+
+@Test func clampedScaledMetricDefaultsMaximum() async throws {
+    struct Holder {
+        @ClampedScaledMetric var value: CGFloat = 12
+    }
+
+    let h = Holder()
+    #expect(h.value == 12)
 }


### PR DESCRIPTION
## Summary
- document `ClampedScaledMetric`
- keep MARK section style and spacing
- drop code formatting around system types
- ensure blank line after initializer summary
- document code organization and style rules in `AGENTS.md`

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6844ac11b0248323b9936bed917d436f